### PR TITLE
[update]旅人用予約変更画面の変更

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,8 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :set_locale
+  # メンバーの登録時に使用する。strong parameter に下記のパラメターを追加する。
+  before_filter :configure_permitted_parameters, if: :devise_controller?
 
   LAN_NAMES =
       { ja: "日本語", en: "English", ko: "한국어",zh: "中文" }
@@ -24,13 +26,8 @@ class ApplicationController < ActionController::Base
     @top_search_guide = Search::Guide.new
   end
 
- # メンバーの登録時に使用する。strong parameter に下記のパラメターを追加する。
-before_filter :configure_permitted_parameters, if: :devise_controller?
-
- protected
-
- def configure_permitted_parameters
-  devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :country_id, :hantei])
-  
- end
+  protected
+  def configure_permitted_parameters
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:first_name, :last_name, :country_id, :hantei])
+  end
 end

--- a/app/controllers/traveler_bookings_controller.rb
+++ b/app/controllers/traveler_bookings_controller.rb
@@ -1,9 +1,12 @@
 class TravelerBookingsController < ApplicationController
+  before_action :authenticate_member!
+  before_action :check_traveler_booking_edit, only: [:edit, :update]
+  # before_action :check_traveler_booking_edit
+
   def index
-    # ログイン機能ができるまでの暫定
     # 更新が新しい順で表示する
-    @Bookings = Booking.where(traveler_id: 4).order(updated_at: :desc)
-    # @Bookings = Booking.find(1)
+    #binding.pry
+    @Bookings = Booking.where(traveler_id: current_member).order(updated_at: :desc)
   end
 
   def show
@@ -13,6 +16,7 @@ class TravelerBookingsController < ApplicationController
   end
 
   def edit
+    # binding.pry
     @Booking = Booking.find(params[:id])
     #traveler commentが存在しない場合、作成する。BuildしておかないとFormが作成されない
     @Booking.build_traveler_booking_comment unless @Booking.traveler_booking_comment
@@ -38,4 +42,9 @@ class TravelerBookingsController < ApplicationController
     params.require(:booking).permit(attrs)
   end
 
+  # 旅人の予約を変更可能か確認（自分の予約しか変更できない）
+  def check_traveler_booking_edit
+    redirect_to(top_url) unless Booking.find(params[:id]).traveler_id == current_member.id
+  end
+  
 end

--- a/app/views/traveler_bookings/edit.html.erb
+++ b/app/views/traveler_bookings/edit.html.erb
@@ -24,7 +24,9 @@
         <tbody>
           <%= f.fields_for :booking_schedules do |bs| %>
             <tr>
-              <td><%= bs.text_field :traveler_date, class: "form-control" %></td>
+              <td>
+                  <%= bs.date_select :traveler_date,{},{class: "form-control", style: "display: inline; width: 30%"} %>
+              </td>
               <td><%= bs.text_field :traveler_count, class: "form-control" %></td>
               <td>
                 <%= bs.select :city_master_id, @Booking.guide.guide_cities.map{|i| [i.city_master.send("text_#{I18n.locale}"), i.city_master.id ]} ,{}, {class: "form-control" } %>

--- a/db/seeds/development/travelers.rb
+++ b/db/seeds/development/travelers.rb
@@ -1,14 +1,5 @@
 #travelers
 Traveler.create(
-  member_id: 1
-)
-Traveler.create(
-  member_id: 2
-)
-Traveler.create(
-  member_id: 3
-)
-Traveler.create(
   member_id: 4
 )
 Traveler.create(


### PR DESCRIPTION
日程をdata_selectで設定する（予約可能日のチェックはない）
ログインしていない場合はログイン画面にリダイレクト(authenticate_member!を使用）
自分の予約しかeditできないようにチェックを追加(check_traveler_booking_edit)