### PR TITLE
javascript include tag deleted

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,8 +7,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track' => true %>
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
-  <%= javascript_include_tag "i18n" %>
-  <%= javascript_include_tag "translations" %>
+  <!--%= javascript_include_tag "i18n" %>-->
+  <!--%= javascript_include_tag "translations" %>-->
   <%= csrf_meta_tags %>
 
   <script type="text/javascript">


### PR DESCRIPTION
heroku動作不備の問題修正試し、
application.html.erbのheaderにある下記内容を削除
<!--%= javascript_include_tag "i18n" %>-->
<!--%= javascript_include_tag "translations" %>-->