### PR TITLE
[fixed]旅人予約作成権限チェックエラー

### DIFF
--- a/app/controllers/guide_bookings_controller.rb
+++ b/app/controllers/guide_bookings_controller.rb
@@ -1,6 +1,6 @@
 class GuideBookingsController < ApplicationController
   before_action :authenticate_member!
-  before_action :check_guide_booking_edit, only: [:edit, :update]
+  before_action :check_guide_booking_edit, only: [:show, :edit, :update]
 
   def index
     # 更新が新しい順で表示する

--- a/app/controllers/traveler_bookings_controller.rb
+++ b/app/controllers/traveler_bookings_controller.rb
@@ -1,6 +1,6 @@
 class TravelerBookingsController < ApplicationController
   before_action :authenticate_member!
-  before_action :check_traveler_booking_edit, only: [:edit, :update]
+  before_action :check_traveler_booking_edit, only: [:show, :edit, :update]
   # before_action :check_traveler_booking_edit
 
   def index
@@ -28,8 +28,7 @@ class TravelerBookingsController < ApplicationController
       @booking.build_traveler_booking_comment
       # binding.pry
     else
-      flash[:notice] = "貴方のいるユーザーグループでは、該当する権限が有りません！"
-      redirect_to guide_detail_path(params[:guide_id])
+      redirect_to top_url, notice: t(".rejected")
     end
   end
 
@@ -91,5 +90,6 @@ class TravelerBookingsController < ApplicationController
     # binding.pry
     redirect_to(top_url) unless Booking.find(params[:id]).traveler == current_member.traveler
   end
+
 
 end

--- a/config/locales/controllers/traveler_bookings/en.yml
+++ b/config/locales/controllers/traveler_bookings/en.yml
@@ -27,3 +27,5 @@ en:
       updated: "Booking is updated."
     destroy:
       cancelled: "Booking is cancelled."
+    new:
+      rejected: "Not authorized for booking."

--- a/config/locales/controllers/traveler_bookings/ja.yml
+++ b/config/locales/controllers/traveler_bookings/ja.yml
@@ -27,3 +27,5 @@ ja:
       updated: "予約を更新しました。"
     destroy:
       cancelled: "予約を取消しました。"
+    new:
+      rejected: "予約する権限がありません"

--- a/config/locales/controllers/traveler_bookings/ko.yml
+++ b/config/locales/controllers/traveler_bookings/ko.yml
@@ -27,3 +27,5 @@ ko:
       updated: "예약을 갱신 하였습니다."
     destroy:
       cancelled: "예약을 취소 하였습니다."
+    new:
+      rejected: "予約する権限がありません_ko"

--- a/config/locales/controllers/traveler_bookings/zh.yml
+++ b/config/locales/controllers/traveler_bookings/zh.yml
@@ -27,3 +27,5 @@ zh:
       updated: "予約を更新しました。_zh"
     destroy:
       cancelled: "予約を取消しました。_zh"
+    new:
+      rejected: "予約する権限がありません_zh"


### PR DESCRIPTION
旅人予約の権限チェックエラーがパラメータがあることが前提だったので
なくてもエラーにならないように変更

他の人が自分の予約を見れないようにshowの時もチェックを追加