### PR TITLE
Issues 222

### DIFF
--- a/app/controllers/traveler_bookings_controller.rb
+++ b/app/controllers/traveler_bookings_controller.rb
@@ -61,6 +61,8 @@ class TravelerBookingsController < ApplicationController
       redirect_to traveler_booking_path(@booking), notice: t(".created")
     else
       # binding.pry
+      # ダミーリダイレクトのpath設定
+      @redirect_path = new_traveler_booking_path(guide_id: @booking.guide_id)
       render "new"
     end
     # redirect_to traveler_bookings_path
@@ -74,6 +76,8 @@ class TravelerBookingsController < ApplicationController
       TravelerBookingMailer.send_update_booking(@booking).deliver_now
       redirect_to traveler_booking_path, notice: t(".updated")
     else
+      # ダミーリダイレクトのpath設定
+      @redirect_path = edit_traveler_booking_path(@booking)
       render "edit"
       # binding.pry
     end

--- a/app/views/traveler_bookings/_booking_schedule.html.erb
+++ b/app/views/traveler_bookings/_booking_schedule.html.erb
@@ -41,7 +41,7 @@
 </table>
 <script type="text/javascript">
   jQuery(document).ready(function($){
-    $('#detail-association-insertion-point').on('click','tr > td:first-child > input[type=text]:not(.hasDatepicker)',function(){
+    $('#detail-association-insertion-point').on('click','td:first-of-type input[readonly][type=text]:not(.hasDatepicker)',function(){
       <%if @booking.id%>
         datePickerHandler($(this),<%= @booking.guide.id%>,<%= @booking.id%>);
       <%else%>

--- a/app/views/traveler_bookings/edit.html.erb
+++ b/app/views/traveler_bookings/edit.html.erb
@@ -1,3 +1,6 @@
+<!--更新失敗の際、urlがshowに変わるから、showがない時f5がエラーになるので、その場合にurl修正-->
+<%= render "shared/redirect"%>
+
 <% content_for :error_messages do %>
   <!-- エラーメッセージの表示エリアをレンダリング-->
   <%= render partial: "shared/error", locals: {obj: @booking} %>

--- a/app/views/traveler_bookings/new.html.erb
+++ b/app/views/traveler_bookings/new.html.erb
@@ -1,3 +1,6 @@
+<!--更新失敗の際、urlがshowに変わるから、showがない時f5がエラーになるので、その場合にurl修正-->
+<%= render "shared/redirect"%>
+
 <% content_for :error_messages do %>
   <!-- エラーメッセージの表示エリアをレンダリング-->
   <%= render partial: "shared/error", locals: {obj: @booking} %>


### PR DESCRIPTION
close #233 
１．カレンダーが開かないバッグの修正
２．新規と更新ページで更新時バリデーションエラーが発生した場合、urlが一覧のurlに変わり「f5」を押すと一覧ページが表示されてしまう為、更新時エラーになった時urlを更新ボタン押下前のurlに設定するように修正
